### PR TITLE
Cap control rod levels to be between 0 and 100

### DIFF
--- a/reactorController.lua
+++ b/reactorController.lua
@@ -537,15 +537,9 @@ local function reDrawButtons()
 end
 
 local function setRods(level)
-    if (reactorVersion == "Big Reactors") then
-        reactor.setAllControlRodLevels(level)
-    elseif (reactorVersion == "Bigger Reactors") then
-        reactor.setAllControlRodLevels(level)
-    elseif (reactorVersion == "Extreme Reactors") then
-        for i in pairs(reactor.getControlRodsLevels()) do
-            reactor.setControlRodLevel(i, level)
-        end
-    end
+    level = math.max(level, 0)
+    level = math.min(level, 100)
+    reactor.setAllControlRodLevels(level)
 end
 
 --Turns off the reactor

--- a/reactorController.lua
+++ b/reactorController.lua
@@ -1,5 +1,5 @@
 local tag = "reactorConfig"
-version = "0.42"
+version = "0.43"
 --[[
 Program made by DrunkenKas
 	See github: https://github.com/Kasra-G/ReactorController/#readme


### PR DESCRIPTION
Simplified setRods to account for recent ER API changes. 
Now the program will ensure that the rod level will always be from 0-100