### PR TITLE
[0.51] Fix Pastebin endpoint, Remove calibration step, use a serializer for config, and some refactors

### DIFF
--- a/reactorController.lua
+++ b/reactorController.lua
@@ -542,6 +542,11 @@ local function initMon()
 
     mon = peripheral.wrap(monSide)
 
+    if mon == nil then
+        monSide = nil
+        return
+    end
+
     resetMon()
     t = touchpoint.new(monSide)
     sizex, sizey = mon.getSize()

--- a/touchpoint.lua
+++ b/touchpoint.lua
@@ -24,7 +24,7 @@ THE SOFTWARE.
 Edited by DrunkenKas.
 	See Github: https://github.com/Kasra-G/ReactorController/#readme
 --]]
-version = "1.0"
+local version = "1.01"
 
 local function setupLabel(buttonLen, minY, maxY, name)
 	local labelTable = {}
@@ -182,3 +182,5 @@ function new(monSide)
 	setmetatable(buttonInstance, {__index = Button})
 	return buttonInstance
 end
+
+touchpoint = {new = new}

--- a/touchpoint.lua
+++ b/touchpoint.lua
@@ -1,3 +1,4 @@
+local version = "1.01"
 --[[
 The MIT License (MIT)
  
@@ -24,7 +25,6 @@ THE SOFTWARE.
 Edited by DrunkenKas.
 	See Github: https://github.com/Kasra-G/ReactorController/#readme
 --]]
-local version = "1.01"
 
 local function setupLabel(buttonLen, minY, maxY, name)
 	local labelTable = {}

--- a/updater.lua
+++ b/updater.lua
@@ -11,7 +11,7 @@ local filesToUpdate = {
 
 function getFile(fileName, link)
   
-  local file = http.get("http://pastebin.com/raw.php?i=" .. textutils.urlEncode(link))
+  local file = http.get("https://pastebin.com/raw/" .. textutils.urlEncode(link))
   
   if file then
     


### PR DESCRIPTION
## Changelist
- Calibration step removed 
  - it was only used for Big Reactors, and at this point I'm not sure who is still running that mod. As such, Big Reactors in the future so that I can use newer CC features and reduce the code complexity (I just want to use `require` instead of `dofile`)
- Config file format updated to use a serializer/deserializer
  - A new config file will be generated from old ones, so settings will persist
- Reduced the coroutine bloat and cleaned up the code a bit
- Pastebin files are now retrieved using the `pastebin get` command instead of directly hitting the pastebin API.
  - This is slightly slower but prevents things from breaking in the future
  - A reinstall is needed for this, fix, unfortunately. Just break the computer/wipe the files and re-install the script

In addition, the monitor resizing is now a bit more responsive, and the program should automatically detect when a monitor has been connected and start drawing to it.

### Why drop BigReactors support
The Big reactors API does not provide a way to get the capacity of the internal buffer (which is why calibration step was previously used). Also, the CC version of that time has some rather annoying limitations, which limits the ceiling for development for newer versions. Please let me know if I'm mistaken

## Checklist before publish/merge

- [x] Test on 1.12 (Working but string formatting is broken due to old CC version)
- [x] Test on 1.18.2
- [x] Test on 1.19.2
- [x] Test on 1.20.1